### PR TITLE
Make package.json scripts work with BSD commands

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -62,7 +62,8 @@ def create_package_json
         "scripts": {
           "build": "esbuild app/javascript/*.* --bundle --outdir=app/assets/builds",
           "build:css": "sass ./app/assets/stylesheets/application.scss ./app/assets/builds/application.css --no-source-map --load-path=node_modules",
-          "postinstall": "cp -rT node_modules/govuk-frontend/govuk/assets/fonts app/assets/builds/fonts && cp -rT node_modules/govuk-frontend/govuk/assets/images app/assets/builds/images"
+          "preinstall": "mkdir -p app/assets/builds/{fonts,images}",
+          "postinstall": "cp -R node_modules/govuk-frontend/govuk/assets/fonts/. app/assets/builds/fonts && cp -R node_modules/govuk-frontend/govuk/assets/images/. app/assets/builds/images"
         }
       }
     JSON


### PR DESCRIPTION
The initial version of the postinstall script used `-rT` which copies recursively (`-r`) and ensures that the source directory isn't copied inside the target (`-T`)

Unfortunately, the BSD variant of cp that ships with macOS doesn't support the `-T` flag.

To work around this we're splitting the command into pre and post install steps; the preinstall ensures the fonts and images directories are present and the postinstall copies the files from `node_modules` to them.
