### PR TITLE
Make template idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,27 @@ This is an application template for starting Ruby on Rails applications with GOV
 
 ## What's included
 
-* asset bundling via [esbuild](https://esbuild.github.io/)
-* [GOV.UK Components](https://govuk-components.netlify.app/)
-* [GOV.UK Form Builder](https://govuk-form-builder.netlify.app/)
-* [RSpec](https://rspec.info/)
+- asset bundling via [esbuild](https://esbuild.github.io/)
+- [GOV.UK Components](https://govuk-components.netlify.app/)
+- [GOV.UK Form Builder](https://govuk-form-builder.netlify.app/)
+- [RSpec](https://rspec.info/)
 
 ## Requirements
 
-* Rails 7.0.1
-* Ruby 3.1.0 (older versions _probably_ work but haven't been tested)
-* [Foreman](https://github.com/ddollar/foreman)
-* [NodeJS](https://nodejs.org/en/)
-* [Yarn](https://yarnpkg.com/)
+- Rails 7.0.1
+- Ruby 3.1.0 (older versions _probably_ work but haven't been tested)
+- [Foreman](https://github.com/ddollar/foreman)
+- [NodeJS](https://nodejs.org/en/)
+- [Yarn](https://yarnpkg.com/)
 
 ## Things that will be added soon
 
-* a Dockerfile
-* GOV.UK PaaS config
+- a Dockerfile
+- GOV.UK PaaS config
 
 ## Example use
 
-To generate a new application called `blog`:
+To generate a new application called `blog` (accept all overwritten files):
 
 ```sh
 rails new                                                                          \


### PR DESCRIPTION
By making the template idempotent, it makes it possible to iterate and continue adding optional features to the template, with downstream users being able to benefit from these improvements by re-running it against their project.

This change makes it possible to run the template against an existing project. It will skip over any already applied changes:

```bash
$ rails new --skip-bundle --skip-jbuilder --skip-test --skip-action-text --skip-action-mailer --skip-action-mailbox \
  -m rails-template/template.rb test-project
$ cd test-project
$ bin/rails app:template LOCATION=../rails-template/template.rb
         run  bundle install from "."
   identical  Procfile.dev
   identical  bin/dev
         run  chmod +x bin/dev from "."
   identical  app/assets/config/manifest.js
   identical  package.json
      remove  app/assets/stylesheets/application.css
   identical  app/assets/stylesheets/application.scss
   identical  app/javascript/application.js
   identical  app/views/layouts/application.html.erb
       exist  app/assets/builds
         run  yarn from "."
$ git status 
On branch main 
nothing to commit, working tree clean 
```

A follow-up PR will document this feature and add a `bin/template` script to newly bootstrapped projects to make it easy to re-run the template.