### PR TITLE
Add support for ADRs

### DIFF
--- a/adr/00001-record-architecture-decisions.md
+++ b/adr/00001-record-architecture-decisions.md
@@ -1,0 +1,20 @@
+# 1. Record architecture decisions
+
+Date: 2022-05-10
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this
+project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/adr/template.rb
+++ b/adr/template.rb
@@ -1,0 +1,33 @@
+inject_into_file(
+  "Gemfile",
+  "gem 'rladr'\n".indent(2),
+  after: "group :development do\n"
+)
+
+run "bin/bundle"
+
+run "bin/bundle exec rladr init adr"
+
+append_to_file(
+  'README.md',
+  <<~MD
+    ## How the application works
+
+    We keep track of architecture decisions in [Architecture Decision Records
+    (ADRs)](/adr/).
+
+    We use `rladr` to generate the boilerplate for new records:
+
+    ```bash
+    bin/bundle exec rladr new title
+    ```
+  MD
+)
+
+template 'adr/00001-record-architecture-decisions.md', force: true
+
+gsub_file(
+  'adr/00001-record-architecture-decisions.md',
+  /2022-05-10/,
+  Time.new.strftime('%Y-%m-%d')
+)

--- a/template.rb
+++ b/template.rb
@@ -21,6 +21,8 @@ def apply_template!
 
   setup_yarn
 
+  add_adrs
+
   after_bundle do
     initialize_git
   end
@@ -148,6 +150,13 @@ def create_bin_bundle
   template('bin/bundle')
 
   chmod "bin/bundle", "+x"
+end
+
+def add_adrs
+  return say('ADRs already supported, skipping') if file_contains?('Gemfile', 'rladr')
+  return unless yes?('Add `rladr` for Architecture Decision Record (ADR) support? y/N')
+
+  apply 'adr/template.rb'
 end
 
 apply_template!


### PR DESCRIPTION
`rladr` is a useful tool for writing ADRs. This codifies setting it up in a new project into the boilerplate.

```bash
...
Add `rladr` for Architecture Decision Record (ADR) support? y/N y 
       apply  /home/deity/git/rails-template/adr/template.rb 
      insert    Gemfile 
         run    bin/bundle from "." 
Fetching gem metadata from https://rubygems.org/.......... 
...
Bundle complete! 16 Gemfile dependencies, 73 gems now installed. 
Use `bundle info [gemname]` to see where a bundled gem is installed. 
         run    bin/bundle exec rladr init adr from "." 
:: Initialized in adr 
:: Created adr/00001-record-architecture-decisions.md 
      append    README.md 
       force    adr/00001-record-architecture-decisions.md 
        gsub    adr/00001-record-architecture-decisions.md 
```