### PR TITLE
Add GOV.UK styled error pages 

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class ErrorsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def not_found
+    render 'not_found', status: :not_found
+  end
+
+  def unprocessable_entity
+    render 'unprocessable_entity', status: :unprocessable_entity
+  end
+
+  def internal_server_error
+    render 'internal_server_error', status: :internal_server_error
+  end
+end

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,0 +1,18 @@
+<%%= content_for :page_title, "Sorry, there’s a problem with the service" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Sorry, there’s a problem with the service</h1>
+
+    <p class="govuk-body">Try again later.</p>
+
+    <p class="govuk-body">
+      If you reached this page after submitting information then it has not
+      been saved. You’ll need to enter it again when the service is available.
+    </p>
+    <p class="govuk-body">
+      If you have any questions, please email us at <a class="govuk-link"
+        href="mailto:<%%= t('service.email') %>"><%%= t('service.email') %></a>.
+    </p>
+  </div>
+</div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,19 @@
+<%%= content_for :page_title, "Page not found" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Page not found</h1>
+    <p class="govuk-body">
+      If you entered a web address, check it is correct.
+    </p>
+    <p class="govuk-body">
+      If you pasted the web address, check you copied the entire address.
+    </p>
+    <p class="govuk-body">
+      If the web address is correct or you selected a link or button and you
+      need to speak to someone about this problem, contact the <%%=
+      t('service.name') %> team: <a class="govuk-link" href="mailto:<%%=
+      t('service.email') %>"><%%= t('service.email') %></a>.
+    </p>
+  </div>
+</div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,0 +1,15 @@
+<%%= content_for :page_title, 'Sorry, there’s a problem with the service' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Sorry, there’s a problem with the service</h1>
+
+    <p class="govuk-body">Try again later.</p>
+
+    <p class="govuk-body">
+      If you continue to see this error contact the <%%= t('service.name')
+      %> team: <a class="govuk-link" href="mailto:<%%= t('service.email') %>"><%%=
+      t('service.email') %></a>.
+    </p>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
-    <title>GOV.UK Frontend on Rails</title>
+    <title><%%= [yield(:page_title).presence, t('service.name')].compact.join(' - ') %></title>
 
     <%%= csrf_meta_tags %>
     <%%= csp_meta_tag %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,4 @@
+en:
+  service:
+    name: GOV.UK Frontend on Rails
+    email: my-service@email

--- a/template.rb
+++ b/template.rb
@@ -18,10 +18,12 @@ def apply_template!
   initialize_formbuilder
 
   add_pages_controller
+  add_en_yml
 
   setup_yarn
 
   add_adrs
+  add_error_pages
 
   setup_asdf
 
@@ -166,6 +168,17 @@ def setup_asdf
   return unless yes?('Add [asdf](https://asdf-vm.com/) for Ruby/Node/Yarn versioning support? y/N')
 
   apply 'templates/asdf.rb'
+end
+
+def add_en_yml
+  template('config/locales/en.yml') if file_contains?('config/locales/en.yml', 'Hello world')
+end
+
+def add_error_pages
+  return say('Error pages already added, skipping') if file_exists?('app/controllers/errors_controller.rb')
+  return unless yes?('Add GOV.UK styled error pages? y/N')
+
+  apply 'templates/errors.rb'
 end
 
 apply_template!

--- a/templates/errors.rb
+++ b/templates/errors.rb
@@ -1,0 +1,26 @@
+template 'app/controllers/errors_controller.rb'
+
+template 'app/views/errors/internal_server_error.html.erb'
+template 'app/views/errors/not_found.html.erb'
+template 'app/views/errors/unprocessable_entity.html.erb'
+
+routes = <<-RUBY
+
+  scope via: :all do
+    get '/404', to: 'errors#not_found'
+    get '/422', to: 'errors#unprocessable_entity'
+    get '/500', to: 'errors#internal_server_error'
+  end
+RUBY
+
+insert_into_file('config/routes.rb', routes, before: 'end')
+
+insert_into_file(
+  'config/application.rb',
+  "\nconfig.exceptions_app = routes\n".indent(4),
+  before: "  end\nend"
+)
+
+remove_file 'public/404.html'
+remove_file 'public/422.html'
+remove_file 'public/500.html'


### PR DESCRIPTION
Also add `service.name` and `service.email` to the locales file, to help populate the error pages and the page title.