### PR TITLE
Migrate from sprockets to propshaft

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,5 @@
-@use "govuk-frontend/govuk/all";
+$govuk-global-styles: true;
+$govuk-new-link-styles: true;
+$govuk-assets-path: "/";
+
+@import "govuk-frontend/govuk/all";

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,3 @@
-import "@hotwired/turbo-rails";
-// import "./controllers";
-
 import { initAll } from "govuk-frontend";
 
 initAll();

--- a/gitignore
+++ b/gitignore
@@ -1,13 +1,21 @@
-# Frontend artifacts and libs
-app/assets/builds/*
-node_modules
-
-# Platform/IDE-specific settings
+!app/assets/builds/.keep
+!log/.keep
+!tmp/.keep
+!tmp/pids/
+!tmp/pids/.keep
+*.log
 .DS_Store
+.bundle
+.env
+.env.local
+.envrc
 .idea
 .vscode
-
-# Local env settings
-.env
-.envrc
-.env.local
+app/assets/builds/*
+config/master.key
+db/*.sqlite3
+log/*
+node_modules
+public/assets
+tmp/*
+tmp/pids/*

--- a/package.json
+++ b/package.json
@@ -2,8 +2,6 @@
   "name": "app",
   "private": "true",
   "dependencies": {
-    "@hotwired/stimulus": "^3.0.1",
-    "@hotwired/turbo-rails": "^7.1.1",
     "govuk-frontend": "^4.0.1",
     "esbuild": "^0.14.23",
     "sass": "^1.49.8"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,6 @@
   },
   "scripts": {
     "build:css": "sass --embed-sources --quiet-deps --load-path=node_modules ./app/assets/stylesheets/application.scss ./app/assets/builds/application.css",
-    "build:js": "esbuild app/javascript/*.* --bundle --outdir=app/assets/builds",
-    "preinstall": "mkdir -p app/assets/builds/{fonts,images}",
-    "postinstall": "cp -R node_modules/govuk-frontend/govuk/assets/fonts/. app/assets/builds/fonts && cp -R node_modules/govuk-frontend/govuk/assets/images/. app/assets/builds/images"
+    "build:js": "esbuild app/javascript/*.* --bundle --outdir=app/assets/builds"
   }
 }


### PR DESCRIPTION
## The problem

Running a fresh app in production mode (`RAILS_ENV=production RAILS_SERVE_STATIC_FILES=true`) with precompiled assets fails to serve the `govuk-crest` and the font.

## The reason

Sprockets doesn't combine well with `cssbundling-rails`; it's in a weird halfway spot where it handles fingerprinting but it doesn't touch any of our CSS or assets that are included via embedded `url()`s. It is capable of moving files from `app/assets/builds` to `public/assets` and fingerprinting them, but it is helpless to actually go in and modify the CSS that `dart-sass` produces, and to replace asset locations with fingerprinted ones.

[govuk-frontend SASS API functions](https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-image-url-function) such as `$govuk-image-url-function` don't help like they do with the previous `webpacker` setup we used, because the fingerprints live inside `sprockets` and it doesn't talk to `dart-sass`.

Long discussion of similar issues and potential solutions (I tried the asset preprocessor route myself, but couldn't make it work): https://github.com/rails/cssbundling-rails/issues/22

## The solution

[rails/propshaft](https://github.com/rails/propshaft) is the exact solution to this problem from the Rails core team. It's a much simpler asset delivery pipeline and with very little configuration accomplishes everything we need:

- We tell it where the `govuk-frontend` assets live
- The ones that are referenced by `asset_path`s in our Ruby code get copied over and fingerprinted
- The ones that are referenced by absolute pathed urls like `url("/images/govuk-crest-2x.png")` in our CSS also get copied over and fingerprinted
- That's it

## Changes proposed in this pull request

Two unrelated commits:

- Update the `gitignore` template, it was missing some stuff like tmp etc
- Remove hotwire/turbo from the default build; was added accidentally previously

Then roughly following the [migration guide](https://github.com/rails/propshaft/blob/main/UPGRADING.md#3-migrate-from-sprockets-to-propshaft).

- Replace `sprockets-rails` with `propshaft` in the Gemfile (including the comment which is useful for people new to this library)
- Add `govuk-frontend` assets to pipeline: `config.assets.paths << Rails.root.join('node_modules/govuk-frontend/govuk/assets')`
- Remove stuff that isn't necessary anymore:
  - `manifest.js`; [see all asset paths that propshaft includes by default](https://github.com/rails/propshaft/blob/main/UPGRADING.md#3-migrate-from-sprockets-to-propshaft)
  - our custom pre/post install hooks in yarn :tada:
  - `config/initializers/assets.rb`
- Add `$govuk-assets-path: "/";` so that URLs look like `url("/images/govuk-crest-2x.png")` and map correctly; this is the `propshaft` convention. `rails assets:reveal` shows all available assets from all sources

## Screenshots

Running the following in a fresh project:

```sh
RAILS_ENV=production rails assets:precompile
RAILS_ENV=production RAILS_SERVE_STATIC_FILES=true rails server
```

| Before (sad! no fonts! :sob: ) | After (happy! yes fonts! :tada: ) |
| - | - |
| ![image](https://user-images.githubusercontent.com/1650875/168577600-1d4a89b6-d6a0-49f5-899b-df9a18ccbae1.png) | ![image](https://user-images.githubusercontent.com/1650875/168577263-e68326fd-43ac-4f44-b2bb-0fd55e5b9ece.png) |