### PR TITLE
Add solargraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is an application template for starting Ruby on Rails applications with GOV
 ## Requirements
 
 - Rails 7.0.x
-- Ruby 3.1.x
+- Ruby 3.1.1
 - [NodeJS 18.x](https://nodejs.org/en/)
 - [Yarn 1.22.x](https://yarnpkg.com/)
 - [Foreman](https://github.com/ddollar/foreman)

--- a/adr/template.rb
+++ b/adr/template.rb
@@ -4,7 +4,7 @@ inject_into_file(
   after: "group :development do\n"
 )
 
-run "bin/bundle"
+run "bin/bundle --quiet"
 
 run "bin/bundle exec rladr init adr"
 

--- a/solargraph.yml
+++ b/solargraph.yml
@@ -1,0 +1,23 @@
+---
+include:
+- "**/*.rb"
+exclude:
+- spec/**/*
+- test/**/*
+- vendor/**/*
+- ".bundle/**/*"
+require: []
+domains: []
+reporters:
+- rubocop
+- require_not_found
+formatter:
+  rubocop:
+    cops: safe
+    except: []
+    only: []
+    extra_args: []
+require_paths: []
+plugins:
+  - solargraph-rails
+max_files: 5000

--- a/template.rb
+++ b/template.rb
@@ -23,10 +23,10 @@ def apply_template!
 
   setup_yarn
 
-  add_adrs
-  add_error_pages
-
+  setup_adrs
+  setup_error_pages
   setup_asdf
+  setup_solargraph
 
   after_bundle do
     initialize_git
@@ -85,7 +85,7 @@ def install_gems
     'propshaft'
   ) if file_contains?("Gemfile", "sprockets-rails")
 
-  run "bundle install"
+  run "bundle --quiet"
 end
 
 def create_procfile
@@ -160,7 +160,7 @@ end
 def setup_yarn
   empty_directory "app/assets/builds"
 
-  run "yarn"
+  run "yarn --silent"
 end
 
 def initialize_git
@@ -181,8 +181,9 @@ def create_bin_bundle
   chmod "bin/bundle", "+x"
 end
 
-def add_adrs
-  return say('ADRs already supported, skipping') if file_contains?('Gemfile', 'rladr')
+def setup_adrs
+  return say('ADRs already setup, skipping') if file_contains?('Gemfile', 'rladr')
+  say("\n=== Architecture Decision Records (ADRs) ===")
   return unless yes?('Add `rladr` for Architecture Decision Record (ADR) support? y/N')
 
   apply 'adr/template.rb'
@@ -190,7 +191,8 @@ end
 
 def setup_asdf
   return say('asdf already setup, skipping') if file_exists?('.tool-versions')
-  return unless yes?('Add [asdf](https://asdf-vm.com/) for Ruby/Node/Yarn versioning support? y/N')
+  say("\n=== `asdf-vm` https://asdf-vm.com/ ===")
+  return unless yes?('Add `asdf` for Ruby/Node/Yarn versioning support? y/N')
 
   apply 'templates/asdf.rb'
 end
@@ -199,11 +201,20 @@ def add_en_yml
   template('config/locales/en.yml') if file_contains?('config/locales/en.yml', 'Hello world')
 end
 
-def add_error_pages
-  return say('Error pages already added, skipping') if file_exists?('app/controllers/errors_controller.rb')
+def setup_error_pages
+  return say('Error pages already setup, skipping') if file_exists?('app/controllers/errors_controller.rb')
+  say("\n=== GOV.UK styled error pages ===")
   return unless yes?('Add GOV.UK styled error pages? y/N')
 
   apply 'templates/errors.rb'
+end
+
+def setup_solargraph
+  return say('solargraph already setup, skipping') if file_exists?('.solargraph.yml')
+  say("\n=== solargraph https://solargraph.org/ ===")
+  return unless yes?('Add solargraph for Ruby intellisense support? y/N')
+
+  apply 'templates/solargraph.rb'
 end
 
 apply_template!

--- a/templates/solargraph.rb
+++ b/templates/solargraph.rb
@@ -1,0 +1,37 @@
+template 'solargraph.yml', '.solargraph.yml'
+
+inject_into_file(
+  "Gemfile",
+  "gem 'annotate', require: false\n" \
+  "gem 'solargraph', require: false\n" \
+  "gem 'solargraph-rails', require: false\n".indent(2),
+  after: "group :development do\n"
+)
+
+run "bin/bundle --quiet"
+
+run "bin/rails generate annotate:install"
+
+append_to_file(
+  'README.md',
+  <<~MD
+    ### Intellisense
+
+    [solargraph](https://github.com/castwide/solargraph) is bundled as part of the
+    development dependencies. You need to [set it up for your
+    editor](https://github.com/castwide/solargraph#using-solargraph), and then run
+    this command to index your local bundle (re-run if/when we install new
+    dependencies and you want completion):
+
+    ```sh
+    bin/bundle exec yard gems
+    ```
+
+    You'll also need to configure your editor's `solargraph` plugin to
+    `useBundler`:
+
+    ```diff
+    +  "solargraph.useBundler": true,
+    ```
+  MD
+)


### PR DESCRIPTION
See also:

- https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/19
- https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/23

[solargraph](https://github.com/castwide/solargraph) is a Ruby language server protocol; it provides intellisense capabilities to [compatible editors](https://github.com/castwide/solargraph#using-solargraph).

`solargraph` can be used without adding a `development` dependency to a project, and it provides basic Ruby language completion for core language features. To set it up to work with our bespoke modules, gems, and Rails, you need to bundle it and run a command. I've documented this in the README.

The gem is `require: false`d and is not bundled in the production build.

`annotate` and `solargraph-rails` are added for better Rails support.

| Before | After |
| - | - |
| Vim doesn't know what classes are under the ActiveModel::Type namespace | Full class list and inline documentation |
| ![image](https://user-images.githubusercontent.com/1650875/168996614-1569cee6-48aa-455e-ac94-4dd0cc7d5ac4.png) | ![image](https://user-images.githubusercontent.com/1650875/168997430-69c06b0f-fbfb-4466-86f2-07ed94ab6f4d.png) |
| String based autocompletion of instance methods |  Static analysis |
| ![image](https://user-images.githubusercontent.com/1650875/168996796-495d6fb4-b0fb-4240-896b-eae0aad66943.png) | ![image](https://user-images.githubusercontent.com/1650875/168997511-44188867-e089-495c-a61a-a7b76d05de73.png) |