### PR TITLE
Add error page for 429 errors

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -10,6 +10,10 @@ class ErrorsController < ApplicationController
     render 'unprocessable_entity', status: :unprocessable_entity
   end
 
+  def too_many_requests
+    render 'too_many_requests', status: :too_many_requests
+  end
+
   def internal_server_error
     render 'internal_server_error', status: :internal_server_error
   end

--- a/app/views/errors/too_many_requests.html.erb
+++ b/app/views/errors/too_many_requests.html.erb
@@ -1,0 +1,19 @@
+<%= content_for :page_title, "Sorry, there’s a problem with the service" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Sorry, there’s a problem with the service</h1>
+
+    <p class="govuk-body">Try again later.</p>
+
+    <p class="govuk-body">
+      You’re seeing this message as you’ve tried to access this page
+      repeatedly, please wait a few moments before trying again.
+    </p>
+
+    <p class="govuk-body">
+      If you have any questions, please email us at
+      <a class="govuk-link" href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.
+    </p>
+  </div>
+</div>

--- a/templates/errors.rb
+++ b/templates/errors.rb
@@ -9,6 +9,7 @@ routes = <<-RUBY
   scope via: :all do
     get '/404', to: 'errors#not_found'
     get '/422', to: 'errors#unprocessable_entity'
+    get '/429', to: 'errors#too_many_requests'
     get '/500', to: 'errors#internal_server_error'
   end
 RUBY


### PR DESCRIPTION
Apply and Find recently added support for `rack_attack`. While setting that up feels a bit bespoke, the error template for 429s feels generic and like something that can be a sensible default in the template.