### PR TITLE
Specify 'main' as the initial branch

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -145,7 +145,7 @@ end
 def initialize_git
   template('gitignore', '.gitignore')
 
-  git(:init)
+  git(init: "--initial-branch=main")
   git(add: ".")
   git(commit: <<~COMMIT)
     -m "Initial commit


### PR DESCRIPTION
`git init` uses `master` as the default branch name but v2.28.0 onwards allows us to specify an initial branch.