### PR TITLE
Create app/assets/builds/.keep

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-bin/bundle exec rubocop --auto-correct-all
+bin/bundle exec rubocop --autocorrect-all
 yarn prettier --write --ignore-unknown '**/*'

--- a/template.rb
+++ b/template.rb
@@ -10,6 +10,7 @@ def apply_template!
   create_application_scss
   create_application_js
   create_application_html_erb
+  create_builds_keep
 
   initialize_rspec
   initialize_formbuilder
@@ -87,6 +88,11 @@ end
 
 def create_application_html_erb
   template('app/views/layouts/application.html.erb')
+end
+
+def create_builds_keep
+  FileUtils.mkdir_p 'app/assets/builds'
+  FileUtils.touch 'app/assets/builds/.keep'
 end
 
 def add_pages_controller


### PR DESCRIPTION
The lack of this prevents the Dockerfile from creating a production ready build on a freshly cloned project.

Also quickly fix a rubocop deprecation warning.