### PR TITLE
add rspec to development env in Gemfile

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -71,7 +71,7 @@ def install_gems
   gem "govuk_design_system_formbuilder" unless
     file_contains?("Gemfile", "govuk_design_system_formbuilder")
 
-  gem_group :test do
+  gem_group :test, :development do
     gem "rspec"
     gem "rspec-rails"
   end unless file_contains?("Gemfile", 'rspec-rails')


### PR DESCRIPTION
Otherwise, rspec isn't available in the development environment, causing 'rails generate' to create unit tests instead of rspecs. This change ensures it creates rspecs.

For example, generating a model before this change (note `test_unit` used):

```
~/Code/apply-for-a-juggling-licence$ rails generate model juggler
      invoke  active_record
      create    db/migrate/20221220145746_create_jugglers.rb
      create    app/models/juggler.rb
      invoke    test_unit
      create      test/models/juggler_test.rb
      create      test/fixtures/jugglers.yml
```

And generating a model with this change (note `rspec` used):

```
~/Code/apply-for-a-juggling-licence$ rails generate model juggler
      invoke  active_record
      create    db/migrate/20221220145908_create_jugglers.rb
      create    app/models/juggler.rb
      invoke    rspec
      create      spec/models/juggler_spec.rb
```
