### PR TITLE
Upgrade to GOV.UK Frontend 4.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ makes starting a new GOV.UK Rails project fast and fun.
 
 ## What's included
 
-- [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend)
+- [GOV.UK Frontend 4.4.1](https://github.com/alphagov/govuk-frontend)
 - [GOV.UK Components](https://govuk-components.netlify.app/)
 - [GOV.UK Form Builder](https://govuk-form-builder.netlify.app/)
 - [RSpec](https://rspec.info/)

--- a/template.rb
+++ b/template.rb
@@ -152,7 +152,7 @@ def initialize_govuk_frontend_assets
 end
 
 def setup_yarn
-  run "yarn --silent add govuk-frontend@4.0.1"
+  run "yarn --silent add govuk-frontend@4.4.1"
 end
 
 def initialize_git


### PR DESCRIPTION
The supported version number has also been added to the README to [support the inclusion in the list of community resources](https://github.com/alphagov/govuk-design-system/pull/2552).