### PR TITLE
Update template nav items with new VC syntax

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,9 +28,9 @@
     <%%= govuk_skip_link %>
 
     <%%= govuk_header(service_name: "GOV.UK Rails Boilerplate") do |header| %>
-      <%%= header.navigation_item(text: "Navigation item 1", href: "#", active: true) %>
-      <%%= header.navigation_item(text: "Navigation item 2", href: "#") %>
-      <%%= header.navigation_item(text: "Navigation item 3", href: "#") %>
+      <%%= header.with_navigation_item(text: "Navigation item 1", href: "#", active: true) %>
+      <%%= header.with_navigation_item(text: "Navigation item 2", href: "#") %>
+      <%%= header.with_navigation_item(text: "Navigation item 3", href: "#") %>
     <%% end %>
 
     <div class="govuk-width-container">


### PR DESCRIPTION
ViewComponent now requires slots to be prefixed with `with_`
