### PR TITLE
Add docker-compose with postgres

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -24,6 +24,7 @@ def apply_template!
   add_pages_controller
   add_en_yml
   add_docker
+  add_docker_compose
 
   setup_yarn
 
@@ -219,6 +220,10 @@ end
 def add_docker
   template('Dockerfile')
   template('dockerignore', '.dockerignore')
+end
+
+def add_docker_compose
+  apply 'templates/docker_compose.rb'
 end
 
 def setup_error_pages

--- a/templates/docker_compose.rb
+++ b/templates/docker_compose.rb
@@ -1,0 +1,13 @@
+template('docker-compose.yml','docker-compose.yml')
+append_to_file(
+  'docker-compose.yml',
+  <<~MD
+    # services:
+    # db:
+    #   image: "postgres:#{ENV["ASDF_POSTGRES_VERSION"]}-alpine"
+    #   environment:
+    #     POSTGRES_HOST_AUTH_METHOD: "trust"
+    #   ports:
+    #     - 5432:5432
+  MD
+)


### PR DESCRIPTION
https://trello.com/c/ZkhLTiIl/21-updating-a-template-code

We add docker-compose to the repo for quicker bootstrap.
This is meant for local use only and not for production use.
We focus on postgres but other dependencies can be added(redis).