### PR TITLE
Upgrade to govuk-frontend 5.2.0

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -2,4 +2,4 @@ $govuk-global-styles: true;
 $govuk-new-link-styles: true;
 $govuk-assets-path: "/";
 
-@import "govuk-frontend/govuk/all";
+@import "govuk-frontend/dist/govuk/all";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,11 +10,8 @@
     <%%= tag :meta, property: 'og:image', content: asset_path('images/govuk-opengraph-image.png') %>
     <%%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
     <%%= favicon_link_tag asset_path('images/favicon.ico') %>
-    <%%= favicon_link_tag asset_path('images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
-    <%%= favicon_link_tag asset_path('images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
-    <%%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
-    <%%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
-    <%%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
+    <%%= favicon_link_tag asset_path('images/govuk-icon-mask.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b1c0c" %>
+    <%%= favicon_link_tag asset_path('images/govuk-icon-180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
 
     <%%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
 
   <body class="govuk-template__body">
     <script>
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+      document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
     </script>
 
     <%%= govuk_skip_link %>

--- a/template.rb
+++ b/template.rb
@@ -145,7 +145,7 @@ def initialize_govuk_frontend_assets
 
   insert_into_file(
     'config/application.rb',
-    "\nconfig.assets.paths << Rails.root.join('node_modules/govuk-frontend/govuk/assets')\n".indent(4),
+    "\nconfig.assets.paths << Rails.root.join('node_modules/govuk-frontend/dist/govuk/assets')\n".indent(4),
     before: "  end\nend"
   )
 
@@ -154,7 +154,7 @@ end
 
 def setup_yarn
   run "yarn set version latest"
-  run "yarn --silent add govuk-frontend@4.7.0"
+  run "yarn --silent add govuk-frontend@5.2.0"
 end
 
 def initialize_git


### PR DESCRIPTION
This is mainly a case of fixing the paths (which now start with govuk-frontend/dist/govuk instead of govuk-frontend/dist) and removing the Apple-specific images.
