### PR TITLE
Switch from Yarn 1 to Yarn 4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN bundler -v && \
 
 # Install node packages defined in package.json
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile --check-files
+RUN yarn install --immutable
 
 # Copy all files to /app (except what is defined in .dockerignore)
 COPY . .

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -18,6 +18,16 @@
               .dig("dependencies", "govuk-frontend")
               .tr("^", "")
           }
+        },
+        { key: {
+          text: "Yarn version" },
+          value: {
+            text: File
+              .read(Rails.root.join(".yarnrc.yml"))
+              .match(/releases\/yarn-(?<version>\d+\.\d+\.\d+)\.cjs/)
+              .named_captures
+              .fetch("version", "Problem retrieving Yarn version")
+          }
         }
       ]
     ) %>

--- a/gitignore
+++ b/gitignore
@@ -6,6 +6,7 @@
 .envrc
 .idea
 .vscode
+.yarn
 config/master.key
 db/*.sqlite3
 node_modules

--- a/gitignore
+++ b/gitignore
@@ -6,7 +6,15 @@
 .envrc
 .idea
 .vscode
-.yarn
+
+.yarn/*
+!.yarn/cache
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+
 config/master.key
 db/*.sqlite3
 node_modules

--- a/template.rb
+++ b/template.rb
@@ -153,7 +153,9 @@ def initialize_govuk_frontend_assets
 end
 
 def setup_yarn
-  run "yarn set version latest"
+  apply 'templates/yarn.rb'
+
+  run "yarn set version stable"
   run "yarn --silent add govuk-frontend@5.2.0"
 end
 

--- a/templates/yarn.rb
+++ b/templates/yarn.rb
@@ -1,0 +1,1 @@
+template('yarnrc.yml', '.yarnrc.yml')

--- a/yarnrc.yml
+++ b/yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
It makes sense for new projects to start on the latest version of Yarn 🧶

4 has been out for some time now, confusingly it has its own 'package manager' so we install Yarn in the usual way then specify the version we want to use with `yarn set version stable`. Even more confusingly, `yarn set version latest` targets v1, which hasn't been the latest for years. There's more info on that in [Yarn's questions and answers](https://yarnpkg.com/getting-started/qa).

![image](https://github.com/DFE-Digital/rails-template/assets/128088/6e486e68-f3d9-4a85-ac80-ee7831e1dc40)

