### PR TITLE
Use service nav instead of header nav

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,11 +24,18 @@
 
     <%%= govuk_skip_link %>
 
-    <%%= govuk_header(service_name: "GOV.UK Rails Boilerplate") do |header| %>
-      <%%= header.with_navigation_item(text: "Navigation item 1", href: "#", active: true) %>
-      <%%= header.with_navigation_item(text: "Navigation item 2", href: "#") %>
-      <%%= header.with_navigation_item(text: "Navigation item 3", href: "#") %>
-    <%% end %>
+    <%%= govuk_header %>
+
+    <%%=
+      govuk_service_navigation(
+        service_name: "GOV.UK Rails Boilerplate",
+        navigation_items: [
+          { text: "Navigation item 1", href: "#", active: true },
+          { text: "Navigation item 2", href: "#" },
+          { text: "Navigation item 3", href: "#" }
+        ]
+      )
+    %>
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content" role="main">


### PR DESCRIPTION
Navigation items are soon going to be removed from the header and the reccomendation is that they go in the service nav instead.

https://design-system.service.gov.uk/components/service-navigation/

## How it looks now.

![image](https://github.com/user-attachments/assets/37dccdd8-2fb2-4866-ad64-5fc2292cf8c2)

