### PR TITLE
[xxxx] Fixed sass issues

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -2,4 +2,4 @@ $govuk-global-styles: true;
 $govuk-new-link-styles: true;
 $govuk-assets-path: "/";
 
-@import "govuk-frontend/dist/govuk/all";
+@import "govuk-frontend/dist/govuk";


### PR DESCRIPTION
Fixed warning related to ` 'govuk/all'` is deprecated
```txt
...

Warning: Importing using 'govuk/all' is deprecated. Update your import statement to import 'govuk/index'. To silence this warning, update $govuk-suppressed-warnings with key: "import-using-all"
...
```



occurs running

```bash
bundle exec rails assets:precompile
```

