### PR TITLE
Add `--skip-action-cable` to example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ rails new \
   --skip-action-mailbox \
   --skip-action-mailer \
   --skip-action-text \
+  --skip-action-cable \
   --javascript=esbuild \
   --css=sass \
   -m https://raw.githubusercontent.com/DFE-Digital/rails-template/main/template.rb \


### PR DESCRIPTION
### Context

This adds the `--skip-action-cable` flag to the example `rails new` command, reflecting best practice for GOV.UK-style services, which typically don’t require real-time features.

Skipping Action Cable avoids generating unused files like `cable.yml` and `app/channels/`, and helps reduce unnecessary infrastructure and configuration overhead.